### PR TITLE
Update Card component to use average ratings for display and adjust r…

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -11,6 +11,8 @@ ratings.forEach((rating) => {
   }
 });
 
+let ratingsMedia = Math.round(ratings.reduce((acc, rating) => acc + rating.rating, 0) / ratings.length);
+
 const uniqueRatingName = `rating-${id}`;
 
 const modalId = `modal-${id}`;
@@ -41,7 +43,7 @@ const modalId = `modal-${id}`;
           type="radio"
           name={uniqueRatingName}
           class="rating-hidden"
-          checked={ratingsNum === 0}
+          checked={ratingsMedia === 0}
           disabled
         />
         <input
@@ -49,7 +51,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-1 bg-orange-500"
           aria-label="0.5 star"
-          checked={ratingsNum === 1}
+          checked={ratingsMedia === 1}
           disabled
         />
         <input
@@ -57,7 +59,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-2 bg-orange-500"
           aria-label="1 star"
-          checked={ratingsNum === 2}
+          checked={ratingsMedia === 2}
           disabled
         />
         <input
@@ -65,7 +67,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-1 bg-orange-500"
           aria-label="1.5 star"
-          checked={ratingsNum === 3}
+          checked={ratingsMedia === 3}
           disabled
         />
         <input
@@ -73,7 +75,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-2 bg-orange-500"
           aria-label="2 star"
-          checked={ratingsNum === 4}
+          checked={ratingsMedia === 4}
           disabled
         />
         <input
@@ -81,7 +83,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-1 bg-orange-500"
           aria-label="2.5 star"
-          checked={ratingsNum === 5}
+          checked={ratingsMedia === 5}
           disabled
         />
         <input
@@ -89,7 +91,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-2 bg-orange-500"
           aria-label="3 star"
-          checked={ratingsNum === 6}
+          checked={ratingsMedia === 6}
           disabled
         />
         <input
@@ -97,7 +99,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-1 bg-orange-500"
           aria-label="3.5 star"
-          checked={ratingsNum === 7}
+          checked={ratingsMedia === 7}
           disabled
         />
         <input
@@ -105,7 +107,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-2 bg-orange-500"
           aria-label="4 star"
-          checked={ratingsNum === 8}
+          checked={ratingsMedia === 8}
           disabled
         />
         <input
@@ -113,7 +115,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-1 bg-orange-500"
           aria-label="4.5 star"
-          checked={ratingsNum === 9}
+          checked={ratingsMedia === 9}
           disabled
         />
         <input
@@ -121,7 +123,7 @@ const modalId = `modal-${id}`;
           name={uniqueRatingName}
           class="mask mask-star-2 mask-half-2 bg-orange-500"
           aria-label="5 star"
-          checked={ratingsNum === 10}
+          checked={ratingsMedia === 10}
           disabled
         />
       </div>
@@ -132,7 +134,7 @@ const modalId = `modal-${id}`;
       </div>
     </div>
     <p class="mt-2 text-sm text-gray-600" transition:name={`rater-text-${id}`}>
-      Puntuación: {ratingsNum}/10
+      Puntuación: {ratingsMedia}/10
     </p>
   </div>
   <a href=`/${id}` class="w-full">

--- a/src/pages/[noodle].astro
+++ b/src/pages/[noodle].astro
@@ -67,7 +67,7 @@ const noodleData = data.find((noodle) => noodle.id === id);
                   );
                 })}
               </div>
-              <p class="text-gray-600">{rating.review ?? "Sin reseña"}</p>
+              <p class="text-gray-600">{rating.review ?? ""}</p>
             </li>
           ))
         }


### PR DESCRIPTION
This pull request refactors the rating system in the `Card.astro` component to calculate and display the average rating (`ratingsMedia`) instead of using a precomputed value (`ratingsNum`). Additionally, it includes a minor adjustment to the `noodle` page to handle empty reviews more gracefully.

### Changes to the rating system:

* Introduced `ratingsMedia`, which calculates the average rating by rounding the sum of all ratings divided by their count, replacing the use of `ratingsNum` throughout the `Card.astro` component. (`src/components/Card.astro`, [[1]](diffhunk://#diff-6d256f41fd465113638dc9119e16a077e588b1a494834563f84132704f49bb91R14-R15) [[2]](diffhunk://#diff-6d256f41fd465113638dc9119e16a077e588b1a494834563f84132704f49bb91L44-R126) [[3]](diffhunk://#diff-6d256f41fd465113638dc9119e16a077e588b1a494834563f84132704f49bb91L135-R137)

### Minor adjustment to review handling:

* Updated the `noodle` page to display an empty string instead of "Sin reseña" when a review is not provided. (`src/pages/[noodle].astro`, [src/pages/[noodle].astroL70-R70](diffhunk://#diff-5890b2a6bb5f437e1ba92cd3f174f152bd8715fa54783af1622ca888525119d7L70-R70))